### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPluginWithGradle(useContainerAgent: true)


### PR DESCRIPTION
The buildPlugin syntax is reserved for plugins using maven, and deprecated for plugins using gradle to build.
The change proposed updates the syntax to use the proper buildPluginWithGradle build step.

I'll expedite the merge, once the infrastructure changes to ci.jenkins.io have been merged into production, to prevent failing builds on the default branch and new pull requests.